### PR TITLE
Fix sequelize deprecated message, turn off SQL logging for tests by default

### DIFF
--- a/domain/config/config.js
+++ b/domain/config/config.js
@@ -1,4 +1,47 @@
+const Sequelize = require('sequelize')
 require('dotenv').config()
+
+// Switch to true to see all executed SQL queries while running tests.
+const logSqlQueriesTests = false
+
+// Use symbol based operators with same shortcuts as (deprecated) string operators.
+const Op = Sequelize.Op
+const operatorsAliases = {
+  $eq: Op.eq,
+  $ne: Op.ne,
+  $gte: Op.gte,
+  $gt: Op.gt,
+  $lte: Op.lte,
+  $lt: Op.lt,
+  $not: Op.not,
+  $in: Op.in,
+  $notIn: Op.notIn,
+  $is: Op.is,
+  $like: Op.like,
+  $notLike: Op.notLike,
+  $iLike: Op.iLike,
+  $notILike: Op.notILike,
+  $regexp: Op.regexp,
+  $notRegexp: Op.notRegexp,
+  $iRegexp: Op.iRegexp,
+  $notIRegexp: Op.notIRegexp,
+  $between: Op.between,
+  $notBetween: Op.notBetween,
+  $overlap: Op.overlap,
+  $contains: Op.contains,
+  $contained: Op.contained,
+  $adjacent: Op.adjacent,
+  $strictLeft: Op.strictLeft,
+  $strictRight: Op.strictRight,
+  $noExtendRight: Op.noExtendRight,
+  $noExtendLeft: Op.noExtendLeft,
+  $and: Op.and,
+  $or: Op.or,
+  $any: Op.any,
+  $all: Op.all,
+  $values: Op.values,
+  $col: Op.col
+}
 
 module.exports = {
   development: {
@@ -7,6 +50,7 @@ module.exports = {
     password: process.env.DB_PASSWORD,
     host: process.env.DB_HOST,
     dialect: 'postgres',
+    operatorsAliases,
   },
   test: {
     database: process.env.DB_NAME_TEST,
@@ -14,6 +58,8 @@ module.exports = {
     password: process.env.DB_PASSWORD,
     host: process.env.DB_HOST,
     dialect: 'postgres',
+    logging: logSqlQueriesTests,
+    operatorsAliases,
   },
   production: {
     database: process.env.DB_NAME_PROD,
@@ -21,5 +67,6 @@ module.exports = {
     password: process.env.DB_PASSWORD,
     host: process.env.DB_HOST,
     dialect: 'postgres',
+    operatorsAliases,
   }
 }


### PR DESCRIPTION
The warning was complaining about using string operators instead of symbol ones.